### PR TITLE
fit the directory to nvim lua plugin structure

### DIFF
--- a/lua/throttle-debounce/init.lua
+++ b/lua/throttle-debounce/init.lua
@@ -2,16 +2,16 @@ local M = {}
 
 ---Validates args for `throttle()` and  `debounce()`.
 local function td_validate(fn, ms)
-	vim.validate{
-		fn = { fn, 'f' },
+	vim.validate({
+		fn = { fn, "f" },
 		ms = {
 			ms,
-			function(ms)
-				return type(ms) == 'number' and ms > 0
+			function(inner_ms)
+				return type(inner_ms) == "number" and inner_ms > 0
 			end,
 			"number > 0",
 		},
-	}
+	})
 end
 
 --- Throttles a function on the leading edge. Automatically `schedule_wrap()`s.
@@ -34,6 +34,7 @@ function M.throttle_leading(fn, ms)
 			pcall(vim.schedule_wrap(fn), select(1, ...))
 		end
 	end
+
 	return wrapped_fn, timer
 end
 
@@ -55,8 +56,8 @@ function M.throttle_trailing(fn, ms, last)
 	if not last then
 		function wrapped_fn(...)
 			if not running then
-				local argv = {...}
-				local argc = select('#', ...)
+				local argv = { ... }
+				local argc = select("#", ...)
 
 				timer:start(ms, 0, function()
 					running = false
@@ -68,8 +69,8 @@ function M.throttle_trailing(fn, ms, last)
 	else
 		local argv, argc
 		function wrapped_fn(...)
-			argv = {...}
-			argc = select('#', ...)
+			argv = { ... }
+			argc = select("#", ...)
 
 			if not running then
 				timer:start(ms, 0, function()
@@ -104,6 +105,7 @@ function M.debounce_leading(fn, ms)
 			pcall(vim.schedule_wrap(fn), select(1, ...))
 		end
 	end
+
 	return wrapped_fn, timer
 end
 
@@ -123,8 +125,8 @@ function M.debounce_trailing(fn, ms, first)
 
 	if not first then
 		function wrapped_fn(...)
-			local argv = {...}
-			local argc = select('#', ...)
+			local argv = { ... }
+			local argc = select("#", ...)
 
 			timer:start(ms, 0, function()
 				pcall(vim.schedule_wrap(fn), unpack(argv, 1, argc))
@@ -133,8 +135,8 @@ function M.debounce_trailing(fn, ms, first)
 	else
 		local argv, argc
 		function wrapped_fn(...)
-			argv = argv or {...}
-			argc = argc or select('#', ...)
+			argv = argv or { ... }
+			argc = argc or select("#", ...)
 
 			timer:start(ms, 0, function()
 				pcall(vim.schedule_wrap(fn), unpack(argv, 1, argc))
@@ -160,16 +162,16 @@ function M.test_defer(bouncer, ms, firstlast)
 
 	local timeout = ms or 2000
 
-	local bounced = bouncers[bouncer](
-		function(i) vim.cmd('echom "' .. bouncer .. ': ' .. i .. '"') end,
-		timeout,
-		firstlast
-	)
+	local bounced = bouncers[bouncer](function(i)
+		vim.cmd('echom "' .. bouncer .. ": " .. i .. '"')
+	end, timeout, firstlast)
 
-	for i, _ in ipairs{1,2,3,4,5} do
+	for i, _ in ipairs({ 1, 2, 3, 4, 5 }) do
 		bounced(i)
-		vim.schedule(function () vim.cmd('echom ' .. i) end)
-		vim.fn.call("wait", {1000, "v:false"})
+		vim.schedule(function()
+			vim.cmd("echom " .. i)
+		end)
+		vim.fn.call("wait", { 1000, "v:false" })
 	end
 end
 


### PR DESCRIPTION
Hey it's brilliant piece of code and it works really well!

I created this PR to change the directory structure as below

`defer.lua → lua/throttle-debounce/init.lua` which makes it possible to install via package managers such as packer.
And one can import and use this via `require('throttle-debounce').throttle_leading(..., x)`.

You can verify that this works via my fork.

```lua
-- e.g. with packer
use 'ryuheechul/throttle-debounce.nvim'

-- ...

print(vim.inpect(require 'throttle-debounce'))
```

besides the moving the file to another directory, made these two minor changes:
- made two `ms` to not share their names in `td_validate`
- format changes picked by `stylua`